### PR TITLE
[Fix] #165 [Planlist Day Undefined 수정]

### DIFF
--- a/src/components/Plan/PlanList.tsx
+++ b/src/components/Plan/PlanList.tsx
@@ -226,8 +226,11 @@ const PlanList = ({
       // dayCount 초기값
       const initialDayCount = makeDayCountArray(filter);
 
-      setFilterByDay(filter);
-      setDayCount(initialDayCount);
+      if (initialDayCount.length >= dayCount.length) {
+        console.log("초기화 한당!");
+        setFilterByDay(filter);
+        setDayCount(initialDayCount);
+      }
     }
   }, [planCards]);
 


### PR DESCRIPTION
Day만 추가 후 저장 시, 데이터에는 추가한 Day값이 아무것도 존재하지 않기때문에 다시 필터링을 할 때 추가한 Day가 사라지는 현상 수정
=> 조건문